### PR TITLE
Oppdater topic info i README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,75 +41,75 @@ meldingene:
 
 #### Meldinger på `tbd.utbetaling` inneholder disse feltene:
 
-| Felt | Forklaring | |
-| --- | --- | --- |
-| event | "utbetaling_utbetalt" eller "utbetaling_uten_utbetaling" |
-| utbetalingId | NB, flere utbetalingId-er kan peke på samme fagsystemId |
-| fødselsnummer | | |
-| aktørId | | |
-| organisasjonsnummer | | |
-| fom | | |
-| tom | | |
-| forbrukteSykedager | Hvor mange virkesykedager er forbrukt totalt | |
-| gjenståendeSykedager | Hvor mange sykedager det er igjen til maksdato | |
-| automatiskBehandling | Ble utbetalingen utført automatisk? | |
-| arbeidsgiverOppdrag | _Se forklaring i egen tabell_ | |
-| type | En av `UTBETALING`, `ETTERUTBETALING`, `ANNULLERING` eller `REVURDERING`| |
-| utbetalingsdager | En liste av: | |
-| | **Felt** | **Forklaring** |
-| | dato | |
-| | type | _Se forklaring i egen tabell_ |
-| | begrunnelse | Begrunnelse av årsak til avvising, kun inkludert for avviste dager |
+| Felt                 | Forklaring                                                               |                                                                    |
+|----------------------|--------------------------------------------------------------------------|--------------------------------------------------------------------|
+| event                | "utbetaling_utbetalt" eller "utbetaling_uten_utbetaling"                 |
+| utbetalingId         | NB, flere utbetalingId-er kan peke på samme fagsystemId                  |
+| fødselsnummer        |                                                                          |                                                                    |
+| aktørId              |                                                                          |                                                                    |
+| organisasjonsnummer  |                                                                          |                                                                    |
+| fom                  |                                                                          |                                                                    |
+| tom                  |                                                                          |                                                                    |
+| forbrukteSykedager   | Hvor mange virkesykedager er forbrukt totalt                             |                                                                    |
+| gjenståendeSykedager | Hvor mange sykedager det er igjen til maksdato                           |                                                                    |
+| automatiskBehandling | Ble utbetalingen utført automatisk?                                      |                                                                    |
+| arbeidsgiverOppdrag  | _Se forklaring i egen tabell_                                            |                                                                    |
+| type                 | En av `UTBETALING`, `ETTERUTBETALING`, `ANNULLERING` eller `REVURDERING` |                                                                    |
+| utbetalingsdager     | En liste av:                                                             |                                                                    |
+|                      | **Felt**                                                                 | **Forklaring**                                                     |
+|                      | dato                                                                     |                                                                    |
+|                      | type                                                                     | _Se forklaring i egen tabell_                                      |
+|                      | begrunnelse                                                              | Begrunnelse av årsak til avvising, kun inkludert for avviste dager |
 
 #### Arbeidsgiveroppdrag ser slik ut:
 
-| Felt | Forklaring | |
-| --- | --- | --- |
-| mottaker | Organisasjonsnummer ved refusjon, eller fødselsnummer til mottakeren av utbetalingen | |
-| fagområde | `SP` hvis utbetalingen er til søker, eller `SPREF` hvis det er refusjon til arbeidsgiver | |
-| fagsystemId | ID i oppdragssystemet, for utbetalingsoppdraget. Oppdraget kan deles av flere "utbetalinger" | |
-| nettoBeløp | Totalt beløp til utbetaling for hele oppdraget | |
-| utbetalingslinjer | En liste, der hvert element inneholder følgende felter: | |
-| | **Felt** | **Forklaring** |
-| | fom | Fra-dato for denne kombinasjonen av dagsats og grad |
-| | tom | Til-dato |
-| | dagsats | Faktisk utbetalingsbeløp per dag, altså etter gradering |
-| | totalbeløp | Utregning av dagsats ganger antall stønadsdager |
-| | grad | Sykdomsgrad per dag |
-| | stønadsdager | Antall dager mellom FOM og TOM med utbetaling fra Nav. Helligdager er inkludert, men helgedager er ikke |
+| Felt              | Forklaring                                                                                   |                                                                                                         |
+|-------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| mottaker          | Organisasjonsnummer ved refusjon, eller fødselsnummer til mottakeren av utbetalingen         |                                                                                                         |
+| fagområde         | `SP` hvis utbetalingen er til søker, eller `SPREF` hvis det er refusjon til arbeidsgiver     |                                                                                                         |
+| fagsystemId       | ID i oppdragssystemet, for utbetalingsoppdraget. Oppdraget kan deles av flere "utbetalinger" |                                                                                                         |
+| nettoBeløp        | Totalt beløp til utbetaling for hele oppdraget                                               |                                                                                                         |
+| utbetalingslinjer | En liste, der hvert element inneholder følgende felter:                                      |                                                                                                         |
+|                   | **Felt**                                                                                     | **Forklaring**                                                                                          |
+|                   | fom                                                                                          | Fra-dato for denne kombinasjonen av dagsats og grad                                                     |
+|                   | tom                                                                                          | Til-dato                                                                                                |
+|                   | dagsats                                                                                      | Faktisk utbetalingsbeløp per dag, altså etter gradering                                                 |
+|                   | totalbeløp                                                                                   | Utregning av dagsats ganger antall stønadsdager                                                         |
+|                   | grad                                                                                         | Sykdomsgrad per dag                                                                                     |
+|                   | stønadsdager                                                                                 | Antall dager mellom FOM og TOM med utbetaling fra Nav. Helligdager er inkludert, men helgedager er ikke |
 
 OBS: på `aapen-helse-sporbar` inneholdt beløp-feltet "beløp til utbetaling per dag etter gradering", dette beløpet
 ligger nå i dagsats-feltet.
 
 #### Dagtypene:
 
-| Felt | Forklaring |
-| --- | --- |
-| NavDag | Utbetalingsdag fra Nav |
-| NavHelgDag | Ingen utbetaling grunnet helg, men registrert syk |
-| ArbeidsgiverperiodeDag | Beregnet at arbeidsgiver dekker sykepengeutbetaling |
-| Arbeidsdag | Arbeidstaker var på jobb |
-| Fridag | Arbeidstaker hadde fri |
-| Feriedag | Arbeidstaker hadde ferie |
-| Permisjonsdag | Arbeidstaker hadde permisjon |
-| AvvistDag | Arbeidstaker hadde ikke rett til sykepenger |
-| ForeldetDag | Dagen ligger for langt tilbake i tid til at man kan få sykepenger for den |
-| UkjentDag | Vi har ikke mottatt informasjon om denne dagen, så den regnes som en arbeidsdag |
+| Felt                   | Forklaring                                                                      |
+|------------------------|---------------------------------------------------------------------------------|
+| NavDag                 | Utbetalingsdag fra Nav                                                          |
+| NavHelgDag             | Ingen utbetaling grunnet helg, men registrert syk                               |
+| ArbeidsgiverperiodeDag | Beregnet at arbeidsgiver dekker sykepengeutbetaling                             |
+| Arbeidsdag             | Arbeidstaker var på jobb                                                        |
+| Fridag                 | Arbeidstaker hadde fri                                                          |
+| Feriedag               | Arbeidstaker hadde ferie                                                        |
+| Permisjonsdag          | Arbeidstaker hadde permisjon                                                    |
+| AvvistDag              | Arbeidstaker hadde ikke rett til sykepenger                                     |
+| ForeldetDag            | Dagen ligger for langt tilbake i tid til at man kan få sykepenger for den       |
+| UkjentDag              | Vi har ikke mottatt informasjon om denne dagen, så den regnes som en arbeidsdag |
 
 #### Begrunnelser:
 
-| Kode |
-| --- |
-| SykepengedagerOppbrukt |
-| SykepengedagerOppbruktOver67 |
-| MinimumInntekt |
-| MinimumInntektOver67 |
+| Kode                                  |
+|---------------------------------------|
+| SykepengedagerOppbrukt                |
+| SykepengedagerOppbruktOver67          |
+| MinimumInntekt                        |
+| MinimumInntektOver67                  |
 | EgenmeldingUtenforArbeidsgiverperiode |
-| MinimumSykdomsgrad |
-| EtterDødsdato |
-| ManglerOpptjening |
-| ManglerMedlemskap |
-| Over70 |
+| MinimumSykdomsgrad                    |
+| EtterDødsdato                         |
+| ManglerOpptjening                     |
+| ManglerMedlemskap                     |
+| Over70                                |
 
 Spør om noe er uklart :-)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ meldingene:
 |                                    | type                                                                     | _Se forklaring i egen tabell_                                      |
 |                                    | begrunnelse                                                              | Begrunnelse av årsak til avvising, kun inkludert for avviste dager |
 | antallVedtak                       | Antall vedtak som ligger til grunn for utbetalingen.                     |                                                                    |
-| foreløpigBeregnetSluttPåSykepenger | Foreløig beregnet dato for slutt på sykepenger                           |                                                                    |
+| foreløpigBeregnetSluttPåSykepenger | Foreløpig beregnet dato for slutt på sykepenger                          |                                                                    |
 
 
 #### Arbeidsgiver- og Personoppdrag  ser slik ut:

--- a/README.md
+++ b/README.md
@@ -30,38 +30,44 @@ meldingene:
 | fom                                         |                                                                                                                                                                                                                                                   |
 | tom                                         |                                                                                                                                                                                                                                                   |
 | skjæringstidspunkt                          | Den første dagen i sykefraværet som går ut over arbeidsgiverperioden. Med andre ord dagen etter siste dag søker var på jobb før gjeldende sykefraværsperiode. Vilkårsprøving og fastsetting av sykepengegrunnlaget tar utgangspunkt i denne dagen |
-| dokumenter                                  | Liste av `dokumentId` og `type` til søknaden, sykmeldingen og eventuelt inntektsmeldingen                                                                                                                                                         |
+| hendelseIder                                |                                                                                                                                                                                                                                                   |
 | inntekt                                     | Månedsinntekten som sykepengegrunnlaget beregnes ut fra, for den aktuelle arbeidsgiveren (**Eller for det                                                                                                                                         |
-| aktuelle arbeidsforholdet??**)              |                                                                                                                                                                                                                                                   |
 | sykepengegrunnlag                           | Inntekten som er lagt til grunn for sykepenger, på årsnivå, begrenset oppad til 6G. Inntekter fra flere arbeidsgivere kan inngå i sykepengegrunnlaget.                                                                                            |
 | grunnlagForSykepengegrunnlag                | Den samlede årlige inntekten før evt. begrensning                                                                                                                                                                                                 |
 | grunnlagForSykepengegrunnlagPerArbeidsgiver | Et objekt med orgnummer -> årlig inntekt per arbeidsgiver `{"123456789": 500000.0, "987654321": 700000.0}`                                                                                                                                        |
 | begrensning                                 | Om sykepengegrunnlaget er 6G begrenset. En av disse: `ER_6G_BEGRENSET`, `ER_IKKE_6G_BEGRENSET`, `VURDERT_I_INFOTRYGD` og `VET_IKKE`                                                                                                               |
 | utbetalingId                                | Peker på en "utbetaling", det vil i praksis si en melding på utbetaling-topicen.                                                                                                                                                                  |
+| vedtakFattetTidspunkt                       | Tidspunkt for når vedtaket ble fattet.                                                                                                                                                                                                            |
 
 #### Meldinger på `tbd.utbetaling` inneholder disse feltene:
 
-| Felt                 | Forklaring                                                               |                                                                    |
-|----------------------|--------------------------------------------------------------------------|--------------------------------------------------------------------|
-| event                | "utbetaling_utbetalt" eller "utbetaling_uten_utbetaling"                 |
-| utbetalingId         | NB, flere utbetalingId-er kan peke på samme fagsystemId                  |
-| fødselsnummer        |                                                                          |                                                                    |
-| aktørId              |                                                                          |                                                                    |
-| organisasjonsnummer  |                                                                          |                                                                    |
-| fom                  |                                                                          |                                                                    |
-| tom                  |                                                                          |                                                                    |
-| forbrukteSykedager   | Hvor mange virkesykedager er forbrukt totalt                             |                                                                    |
-| gjenståendeSykedager | Hvor mange sykedager det er igjen til maksdato                           |                                                                    |
-| automatiskBehandling | Ble utbetalingen utført automatisk?                                      |                                                                    |
-| arbeidsgiverOppdrag  | _Se forklaring i egen tabell_                                            |                                                                    |
-| type                 | En av `UTBETALING`, `ETTERUTBETALING`, `ANNULLERING` eller `REVURDERING` |                                                                    |
-| utbetalingsdager     | En liste av:                                                             |                                                                    |
-|                      | **Felt**                                                                 | **Forklaring**                                                     |
-|                      | dato                                                                     |                                                                    |
-|                      | type                                                                     | _Se forklaring i egen tabell_                                      |
-|                      | begrunnelse                                                              | Begrunnelse av årsak til avvising, kun inkludert for avviste dager |
+| Felt                               | Forklaring                                                               |                                                                    |
+|------------------------------------|--------------------------------------------------------------------------|--------------------------------------------------------------------|
+| event                              | "utbetaling_utbetalt" eller "utbetaling_uten_utbetaling"                 |
+| utbetalingId                       | NB, flere utbetalingId-er kan peke på samme fagsystemId                  |
+| fødselsnummer                      |                                                                          |                                                                    |
+| korrelasjonsId                     |                                                                          |                                                                    |
+| aktørId                            |                                                                          |                                                                    |
+| organisasjonsnummer                |                                                                          |                                                                    |
+| fom                                |                                                                          |                                                                    |
+| tom                                |                                                                          |                                                                    |
+| forbrukteSykedager                 | Hvor mange virkesykedager er forbrukt totalt                             |                                                                    |
+| gjenståendeSykedager               | Hvor mange sykedager det er igjen til maksdato                           |                                                                    |
+| stønadsdager                       |                                                                          |                                                                    |
+| automatiskBehandling               | Ble utbetalingen utført automatisk?                                      |                                                                    |
+| arbeidsgiverOppdrag                | _Se forklaring i egen tabell_                                            |                                                                    |
+| personOppdrag                      | _Se forklaring i egen tabell_                                            |                                                                    |
+| type                               | En av `UTBETALING`, `ETTERUTBETALING`, `ANNULLERING` eller `REVURDERING` |                                                                    |
+| utbetalingsdager                   | En liste av:                                                             |                                                                    |
+|                                    | **Felt**                                                                 | **Forklaring**                                                     |
+|                                    | dato                                                                     |                                                                    |
+|                                    | type                                                                     | _Se forklaring i egen tabell_                                      |
+|                                    | begrunnelse                                                              | Begrunnelse av årsak til avvising, kun inkludert for avviste dager |
+| antallVedtak                       | Antall vedtak som ligger til grunn for utbetalingen.                     |                                                                    |
+| foreløpigBeregnetSluttPåSykepenger | Foreløig beregnet dato for slutt på sykepenger                           |                                                                    |
 
-#### Arbeidsgiveroppdrag ser slik ut:
+
+#### Arbeidsgiver- og Personoppdrag  ser slik ut:
 
 | Felt              | Forklaring                                                                                   |                                                                                                         |
 |-------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Oppdaget for en god stund tilbake (ifm. intern ombygging i Team Flex) at DTO-info i README.md har noe avvik i forhold til de faktiske feltene. Tok meg friheten til å oppdatere feltene, men det er et par av de jeg ikke klarte å komme opp med en god beskrivelse på, så tar gjerne en titt.

Kjørte også resten av tabellen gjennom en Markdown-formatering, siden det allerede var gjort for en av tabellene.